### PR TITLE
로그인 기능 구현 + 비밀번호 암호화 + queryDSL 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,14 @@ dependencies {
 	// model-mapper
 	implementation 'org.modelmapper:modelmapper:3.1.1'
 
+	// spring-security
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+
+	// jwt
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -42,8 +42,29 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
+	// queryDSL
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+}
+
+// === ⭐ QueryDsl 빌드 옵션 (선택) ===
+def querydslDir = "$buildDir/generated/querydsl"
+
+sourceSets {
+	main.java.srcDirs += [ querydslDir ]
+}
+
+tasks.withType(JavaCompile) {
+	options.annotationProcessorGeneratedSourcesDirectory = file(querydslDir)
+}
+
+clean.doLast {
+	file(querydslDir).deleteDir()
 }
 
 tasks.named('test') {

--- a/src/main/generated/com/example/architecture/model/entity/QComment.java
+++ b/src/main/generated/com/example/architecture/model/entity/QComment.java
@@ -1,0 +1,64 @@
+package com.example.architecture.model.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QComment is a Querydsl query type for Comment
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QComment extends EntityPathBase<Comment> {
+
+    private static final long serialVersionUID = -764210525L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QComment comment = new QComment("comment");
+
+    public final com.example.architecture.model.entity.baseEntity.QBaseEntity _super = new com.example.architecture.model.entity.baseEntity.QBaseEntity(this);
+
+    public final StringPath content = createString("content");
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> created_at = _super.created_at;
+
+    //inherited
+    public final NumberPath<Long> id = _super.id;
+
+    public final StringPath nickName = createString("nickName");
+
+    public final QPost post;
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> updated_at = _super.updated_at;
+
+    public QComment(String variable) {
+        this(Comment.class, forVariable(variable), INITS);
+    }
+
+    public QComment(Path<? extends Comment> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QComment(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QComment(PathMetadata metadata, PathInits inits) {
+        this(Comment.class, metadata, inits);
+    }
+
+    public QComment(Class<? extends Comment> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.post = inits.isInitialized("post") ? new QPost(forProperty("post"), inits.get("post")) : null;
+    }
+
+}
+

--- a/src/main/generated/com/example/architecture/model/entity/QMember.java
+++ b/src/main/generated/com/example/architecture/model/entity/QMember.java
@@ -1,0 +1,55 @@
+package com.example.architecture.model.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QMember is a Querydsl query type for Member
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QMember extends EntityPathBase<Member> {
+
+    private static final long serialVersionUID = 1499319766L;
+
+    public static final QMember member = new QMember("member1");
+
+    public final com.example.architecture.model.entity.baseEntity.QBaseEntity _super = new com.example.architecture.model.entity.baseEntity.QBaseEntity(this);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> created_at = _super.created_at;
+
+    //inherited
+    public final NumberPath<Long> id = _super.id;
+
+    public final StringPath memberName = createString("memberName");
+
+    public final StringPath nickName = createString("nickName");
+
+    public final StringPath password = createString("password");
+
+    public final ListPath<String, StringPath> roles = this.<String, StringPath>createList("roles", String.class, StringPath.class, PathInits.DIRECT2);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> updated_at = _super.updated_at;
+
+    public QMember(String variable) {
+        super(Member.class, forVariable(variable));
+    }
+
+    public QMember(Path<? extends Member> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QMember(PathMetadata metadata) {
+        super(Member.class, metadata);
+    }
+
+}
+

--- a/src/main/generated/com/example/architecture/model/entity/QPost.java
+++ b/src/main/generated/com/example/architecture/model/entity/QPost.java
@@ -1,0 +1,62 @@
+package com.example.architecture.model.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QPost is a Querydsl query type for Post
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QPost extends EntityPathBase<Post> {
+
+    private static final long serialVersionUID = -1593869604L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QPost post = new QPost("post");
+
+    public final com.example.architecture.model.entity.baseEntity.QBaseEntity _super = new com.example.architecture.model.entity.baseEntity.QBaseEntity(this);
+
+    public final StringPath content = createString("content");
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> created_at = _super.created_at;
+
+    //inherited
+    public final NumberPath<Long> id = _super.id;
+
+    public final QMember member;
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> updated_at = _super.updated_at;
+
+    public QPost(String variable) {
+        this(Post.class, forVariable(variable), INITS);
+    }
+
+    public QPost(Path<? extends Post> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QPost(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QPost(PathMetadata metadata, PathInits inits) {
+        this(Post.class, metadata, inits);
+    }
+
+    public QPost(Class<? extends Post> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.member = inits.isInitialized("member") ? new QMember(forProperty("member")) : null;
+    }
+
+}
+

--- a/src/main/generated/com/example/architecture/model/entity/baseEntity/QBaseEntity.java
+++ b/src/main/generated/com/example/architecture/model/entity/baseEntity/QBaseEntity.java
@@ -1,0 +1,41 @@
+package com.example.architecture.model.entity.baseEntity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QBaseEntity is a Querydsl query type for BaseEntity
+ */
+@Generated("com.querydsl.codegen.DefaultSupertypeSerializer")
+public class QBaseEntity extends EntityPathBase<BaseEntity> {
+
+    private static final long serialVersionUID = 1854026674L;
+
+    public static final QBaseEntity baseEntity = new QBaseEntity("baseEntity");
+
+    public final DateTimePath<java.time.LocalDateTime> created_at = createDateTime("created_at", java.time.LocalDateTime.class);
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final DateTimePath<java.time.LocalDateTime> updated_at = createDateTime("updated_at", java.time.LocalDateTime.class);
+
+    public QBaseEntity(String variable) {
+        super(BaseEntity.class, forVariable(variable));
+    }
+
+    public QBaseEntity(Path<? extends BaseEntity> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QBaseEntity(PathMetadata metadata) {
+        super(BaseEntity.class, metadata);
+    }
+
+}
+

--- a/src/main/java/com/example/architecture/config/QuerydslConfig.java
+++ b/src/main/java/com/example/architecture/config/QuerydslConfig.java
@@ -1,0 +1,19 @@
+package com.example.architecture.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(this.entityManager);
+    }
+}

--- a/src/main/java/com/example/architecture/config/SecurityConfig.java
+++ b/src/main/java/com/example/architecture/config/SecurityConfig.java
@@ -1,0 +1,43 @@
+package com.example.architecture.config;
+
+import com.example.architecture.jwt.JwtAuthenticationFilter;
+import com.example.architecture.jwt.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Bean
+    public BCryptPasswordEncoder passwordEncoder() {
+
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement((sessionManagement) ->
+                        sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests((request) ->
+                        request.requestMatchers("/member/**", "/comment/**", "/post/**").permitAll()
+                                .anyRequest().permitAll())
+                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+}

--- a/src/main/java/com/example/architecture/controller/impl/MemberControllerImpl.java
+++ b/src/main/java/com/example/architecture/controller/impl/MemberControllerImpl.java
@@ -2,7 +2,6 @@ package com.example.architecture.controller.impl;
 
 import com.example.architecture.controller.MemberController;
 import com.example.architecture.controller.generic.impl.BaseControllerImpl;
-import com.example.architecture.jwt.TokenInfo;
 import com.example.architecture.model.entity.Member;
 import com.example.architecture.model.request.LoginRequest;
 import com.example.architecture.model.request.MemberRequest;
@@ -28,11 +27,9 @@ public class MemberControllerImpl extends BaseControllerImpl<Member, MemberReque
     }
 
     @PostMapping("/login")
-    public TokenInfo login(@RequestPart(name = "login")LoginRequest loginRequest) {
+    public String login(@RequestPart(name = "login")LoginRequest loginRequest) {
 
-        String nickName = loginRequest.getNickName();
-        String password = loginRequest.getPassword();
-        TokenInfo tokenInfo = memberService.login(nickName, password);
+        String tokenInfo = memberService.login(loginRequest);
         return tokenInfo;
     }
 }

--- a/src/main/java/com/example/architecture/controller/impl/MemberControllerImpl.java
+++ b/src/main/java/com/example/architecture/controller/impl/MemberControllerImpl.java
@@ -2,19 +2,37 @@ package com.example.architecture.controller.impl;
 
 import com.example.architecture.controller.MemberController;
 import com.example.architecture.controller.generic.impl.BaseControllerImpl;
+import com.example.architecture.jwt.TokenInfo;
 import com.example.architecture.model.entity.Member;
+import com.example.architecture.model.request.LoginRequest;
 import com.example.architecture.model.request.MemberRequest;
 import com.example.architecture.model.response.MemberResponse;
 import com.example.architecture.repository.MemberRepository;
 import com.example.architecture.service.generic.BaseService;
+import com.example.architecture.service.impl.MemberServiceImpl;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping(path = "/member")
 public class MemberControllerImpl extends BaseControllerImpl<Member, MemberRequest, MemberResponse, MemberRepository> implements MemberController {
 
+    @Autowired
+    MemberServiceImpl memberService;
+
     public MemberControllerImpl(BaseService<Member, MemberRequest, MemberResponse, MemberRepository> baseService) {
         super(baseService);
+    }
+
+    @PostMapping("/login")
+    public TokenInfo login(@RequestPart(name = "login")LoginRequest loginRequest) {
+
+        String nickName = loginRequest.getNickName();
+        String password = loginRequest.getPassword();
+        TokenInfo tokenInfo = memberService.login(nickName, password);
+        return tokenInfo;
     }
 }

--- a/src/main/java/com/example/architecture/jwt/CustomUserDetailsService.java
+++ b/src/main/java/com/example/architecture/jwt/CustomUserDetailsService.java
@@ -1,0 +1,36 @@
+package com.example.architecture.jwt;
+
+import com.example.architecture.model.entity.Member;
+import com.example.architecture.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        return memberRepository.findByNickName(username)
+                .map(this::createUserDetails)
+                .orElseThrow(() -> new UsernameNotFoundException("해당하는 유저를 찾을 수 없습니다."));
+    }
+
+    // 해당하는 User 의 데이터가 존재한다면 UserDetails 객체로 만들어서 리턴
+    private UserDetails createUserDetails(Member member) {
+
+        return User.builder()
+                .username(member.getNickName())
+                .password(passwordEncoder.encode(member.getPassword()))
+                .roles(member.getRoles().toArray(new String[0]))
+                .build();
+    }
+}

--- a/src/main/java/com/example/architecture/jwt/CustomUserDetailsService.java
+++ b/src/main/java/com/example/architecture/jwt/CustomUserDetailsService.java
@@ -1,13 +1,10 @@
 package com.example.architecture.jwt;
 
-import com.example.architecture.model.entity.Member;
 import com.example.architecture.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -15,22 +12,11 @@ import org.springframework.stereotype.Service;
 public class CustomUserDetailsService implements UserDetailsService {
 
     private final MemberRepository memberRepository;
-    private final PasswordEncoder passwordEncoder;
 
     @Override
-    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        return memberRepository.findByNickName(username)
-                .map(this::createUserDetails)
-                .orElseThrow(() -> new UsernameNotFoundException("해당하는 유저를 찾을 수 없습니다."));
-    }
+    public UserDetails loadUserByUsername(String nickname) throws UsernameNotFoundException {
 
-    // 해당하는 User 의 데이터가 존재한다면 UserDetails 객체로 만들어서 리턴
-    private UserDetails createUserDetails(Member member) {
-
-        return User.builder()
-                .username(member.getNickName())
-                .password(passwordEncoder.encode(member.getPassword()))
-                .roles(member.getRoles().toArray(new String[0]))
-                .build();
+        return memberRepository.findByNickName(nickname)
+                .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다."));
     }
 }

--- a/src/main/java/com/example/architecture/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/architecture/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,46 @@
+package com.example.architecture.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.GenericFilterBean;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends GenericFilterBean {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+
+        // 1. Request Header 에서 JWT 토큰 추출
+        String token = resolveToken((HttpServletRequest) request);
+
+        // 2. validateToken 으로 토큰 유효성 검사
+        if (token != null && jwtTokenProvider.validateToken(token)) {
+
+            // 토큰이 유효할 경우 토큰에서 Authentication 객체를 가지고 와서 SecurityContext 에 저장
+            Authentication authentication = jwtTokenProvider.getAuthentication(token);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+        chain.doFilter(request, response);
+    }
+
+    // Request Header 에서 토큰 정보 추출
+    private String resolveToken(HttpServletRequest request) {
+
+        String bearerToken = request.getHeader("Authorization");
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer")) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/example/architecture/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/architecture/jwt/JwtAuthenticationFilter.java
@@ -21,26 +21,15 @@ public class JwtAuthenticationFilter extends GenericFilterBean {
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
 
-        // 1. Request Header 에서 JWT 토큰 추출
-        String token = resolveToken((HttpServletRequest) request);
-
-        // 2. validateToken 으로 토큰 유효성 검사
+        // 헤더에서 JWT 를 받아옵니다.
+        String token = jwtTokenProvider.resolveToken((HttpServletRequest) request);
+        // 유효한 토큰인지 확인합니다.
         if (token != null && jwtTokenProvider.validateToken(token)) {
-
-            // 토큰이 유효할 경우 토큰에서 Authentication 객체를 가지고 와서 SecurityContext 에 저장
+            // 토큰이 유효하면 토큰으로부터 유저 정보를 받아옵니다.
             Authentication authentication = jwtTokenProvider.getAuthentication(token);
+            // SecurityContext 에 Authentication 객체를 저장합니다.
             SecurityContextHolder.getContext().setAuthentication(authentication);
         }
         chain.doFilter(request, response);
-    }
-
-    // Request Header 에서 토큰 정보 추출
-    private String resolveToken(HttpServletRequest request) {
-
-        String bearerToken = request.getHeader("Authorization");
-        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer")) {
-            return bearerToken.substring(7);
-        }
-        return null;
     }
 }

--- a/src/main/java/com/example/architecture/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/example/architecture/jwt/JwtTokenProvider.java
@@ -1,113 +1,80 @@
 package com.example.architecture.jwt;
 
-import io.jsonwebtoken.*;
-import io.jsonwebtoken.io.Decoders;
-import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import jakarta.annotation.PostConstruct;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.stereotype.Component;
 
-import java.security.Key;
-import java.util.Arrays;
-import java.util.Collection;
+import java.util.Base64;
 import java.util.Date;
-import java.util.stream.Collectors;
+import java.util.List;
 
 @Slf4j
 @Component
+@RequiredArgsConstructor
 public class JwtTokenProvider {
 
-    private final Key key;
+    @Value("${jwt.secret}")
+    private String secretKey;
+
     @Value("${jwt.access-token-validity-in-seconds}")
-    private Long limitTime;
+    private long tokenValidTime;
 
-    public JwtTokenProvider(@Value("${jwt.secret}") String secretKey) {
-        byte[] keyBytes = Decoders.BASE64.decode(secretKey);
-        this.key = Keys.hmacShaKeyFor(keyBytes);
+    private final UserDetailsService userDetailsService;
+
+    // 객체 초기화, secretKey를 Base64로 인코딩한다.
+    @PostConstruct
+    protected void init() {
+        secretKey = Base64.getEncoder().encodeToString(secretKey.getBytes());
     }
 
-    // 유저 정보를 가지고 AccessToken, RefreshToken 을 생성하는 메서드
-    public TokenInfo generateToken(Authentication authentication) {
-
-        // 권한 가져오기
-        String authorities = authentication.getAuthorities().stream()
-                .map(GrantedAuthority::getAuthority)
-                .collect(Collectors.joining(","));
-
-        long now = (new Date()).getTime();
-
-        // Access Token 생성
-        Date accessTokenExpiresIn = new Date(now + limitTime);
-        String accessToken = Jwts.builder()
-                .setSubject(authentication.getName())
-                .claim("auth", authorities)
-                .setExpiration(accessTokenExpiresIn)
-                .signWith(key, SignatureAlgorithm.HS256)
+    // JWT 토큰 생성
+    public String createToken(String userPk, List<String> roles) {
+        Claims claims = Jwts.claims().setSubject(userPk); // JWT payload 에 저장되는 정보단위, 보통 여기서 user를 식별하는 값을 넣는다.
+        claims.put("roles", roles); // 정보는 key / value 쌍으로 저장된다.
+        Date now = new Date();
+        return Jwts.builder()
+                .setClaims(claims) // 정보 저장
+                .setIssuedAt(now) // 토큰 발행 시간 정보
+                .setExpiration(new Date(now.getTime() + tokenValidTime)) // set Expire Time
+                .signWith(SignatureAlgorithm.HS256, secretKey)  // 사용할 암호화 알고리즘과
+                // signature 에 들어갈 secret값 세팅
                 .compact();
-
-        // Refresh Token 생성
-        String refreshToken = Jwts.builder()
-                .setExpiration(new Date(now + limitTime))
-                .signWith(key, SignatureAlgorithm.HS256)
-                .compact();
-
-        return TokenInfo.builder()
-                .grantType("Bearer")
-                .accessToken(accessToken)
-                .refreshToken(refreshToken)
-                .build();
     }
 
-    // JWT 토큰을 복호화하여 토큰에 들어있는 정보를 꺼내는 메서드
-    public Authentication getAuthentication(String accessToken) {
-
-        // 토큰 복호화
-        Claims claims = parseClaims(accessToken);
-
-        if (claims.get("auth") == null) {
-            throw new RuntimeException("권한 정보가 없는 토큰입니다.");
-        }
-
-        // 클레임에서 권한 정보 가져오기
-        Collection<? extends GrantedAuthority> authorities =
-                Arrays.stream(claims.get("auth").toString().split(","))
-                        .map(SimpleGrantedAuthority::new)
-                        .collect(Collectors.toList());
-
-        // UserDetails 객체를 만들어서 Authentication 리턴
-        UserDetails principle = new User(claims.getSubject(), "", authorities);
-        return new UsernamePasswordAuthenticationToken(principle, "", authorities);
+    // JWT 토큰에서 인증 정보 조회
+    public Authentication getAuthentication(String token) {
+        UserDetails userDetails = userDetailsService.loadUserByUsername(this.getUserPk(token));
+        return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
     }
 
-    // 토큰 정보를 검증하는 메서드
-    public boolean validateToken(String token) {
+    // 토큰에서 회원 정보 추출
+    public String getUserPk(String token) {
+        return Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token).getBody().getSubject();
+    }
 
+    // Request의 Header에서 token 값을 가져옵니다. "Authorization" : "TOKEN값'
+    public String resolveToken(HttpServletRequest request) {
+        return request.getHeader("Authorization");
+    }
+
+    // 토큰의 유효성 + 만료일자 확인
+    public boolean validateToken(String jwtToken) {
         try {
-            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
-            return true;
-        } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
-            log.info("Invalid JWT Token", e);
-        } catch (ExpiredJwtException e) {
-            log.info("Expired JWT Token", e);
-        } catch (UnsupportedJwtException e) {
-            log.info("Unsupported JWT Token", e);
-        } catch (IllegalStateException e) {
-            log.info("JWT claims string is empty", e);
-        }
-        return false;
-    }
-
-    private Claims parseClaims(String accessToken) {
-        try {
-            return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJwt(accessToken).getBody();
-        } catch (ExpiredJwtException e) {
-            return e.getClaims();
+            Jws<Claims> claims = Jwts.parser().setSigningKey(secretKey).parseClaimsJws(jwtToken);
+            return !claims.getBody().getExpiration().before(new Date());
+        } catch (Exception e) {
+            return false;
         }
     }
 }

--- a/src/main/java/com/example/architecture/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/example/architecture/jwt/JwtTokenProvider.java
@@ -1,0 +1,114 @@
+package com.example.architecture.jwt;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Component
+public class JwtTokenProvider {
+
+    private final Key key;
+    @Value("${jwt.access-token-validity-in-seconds}")
+    private Long limitTime;
+
+    public JwtTokenProvider(@Value("${jwt.secret}") String secretKey) {
+        byte[] keyBytes = Decoders.BASE64.decode(secretKey);
+        this.key = Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    // 유저 정보를 가지고 AccessToken, RefreshToken 을 생성하는 메서드
+    public TokenInfo generateToken(Authentication authentication) {
+
+        // 권한 가져오기
+        String authorities = authentication.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.joining(","));
+
+        long now = (new Date()).getTime();
+
+        // Access Token 생성
+        Date accessTokenExpiresIn = new Date(now + limitTime);
+        String accessToken = Jwts.builder()
+                .setSubject(authentication.getName())
+                .claim("auth", authorities)
+                .setExpiration(accessTokenExpiresIn)
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+
+        // Refresh Token 생성
+        String refreshToken = Jwts.builder()
+                .setExpiration(new Date(now + limitTime))
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+
+        return TokenInfo.builder()
+                .grantType("Bearer")
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+
+    // JWT 토큰을 복호화하여 토큰에 들어있는 정보를 꺼내는 메서드
+    public Authentication getAuthentication(String accessToken) {
+
+        // 토큰 복호화
+        Claims claims = parseClaims(accessToken);
+
+        if (claims.get("auth") == null) {
+            throw new RuntimeException("권한 정보가 없는 토큰입니다.");
+        }
+
+        // 클레임에서 권한 정보 가져오기
+        Collection<? extends GrantedAuthority> authorities =
+                Arrays.stream(claims.get("auth").toString().split(","))
+                        .map(SimpleGrantedAuthority::new)
+                        .collect(Collectors.toList());
+
+        // UserDetails 객체를 만들어서 Authentication 리턴
+        UserDetails principle = new User(claims.getSubject(), "", authorities);
+        return new UsernamePasswordAuthenticationToken(principle, "", authorities);
+    }
+
+    // 토큰 정보를 검증하는 메서드
+    public boolean validateToken(String token) {
+
+        try {
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+            return true;
+        } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
+            log.info("Invalid JWT Token", e);
+        } catch (ExpiredJwtException e) {
+            log.info("Expired JWT Token", e);
+        } catch (UnsupportedJwtException e) {
+            log.info("Unsupported JWT Token", e);
+        } catch (IllegalStateException e) {
+            log.info("JWT claims string is empty", e);
+        }
+        return false;
+    }
+
+    private Claims parseClaims(String accessToken) {
+        try {
+            return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJwt(accessToken).getBody();
+        } catch (ExpiredJwtException e) {
+            return e.getClaims();
+        }
+    }
+}
+

--- a/src/main/java/com/example/architecture/jwt/TokenInfo.java
+++ b/src/main/java/com/example/architecture/jwt/TokenInfo.java
@@ -1,0 +1,17 @@
+package com.example.architecture.jwt;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Builder
+@Getter
+@Setter
+@AllArgsConstructor
+public class TokenInfo {
+
+    private String grantType;
+    private String accessToken;
+    private String refreshToken;
+}

--- a/src/main/java/com/example/architecture/model/entity/Member.java
+++ b/src/main/java/com/example/architecture/model/entity/Member.java
@@ -33,7 +33,7 @@ public class Member extends BaseEntity implements UserDetails {
 
         this.memberName = memberRequest.getMemberName();
         this.nickName = memberRequest.getNickName();
-        this.password = memberRequest.getPassword();
+        // this.password = memberRequest.getPassword();
     }
 
     @Override

--- a/src/main/java/com/example/architecture/model/entity/Member.java
+++ b/src/main/java/com/example/architecture/model/entity/Member.java
@@ -4,6 +4,14 @@ import com.example.architecture.model.entity.baseEntity.BaseEntity;
 import com.example.architecture.model.request.MemberRequest;
 import jakarta.persistence.*;
 import lombok.*;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Entity
 @Getter @Setter
@@ -11,16 +19,52 @@ import lombok.*;
 @NoArgsConstructor
 @Builder
 @Table(name = "member")
-public class Member extends BaseEntity {
+public class Member extends BaseEntity implements UserDetails {
 
     private String memberName;
     private String nickName;
     private String password;
+
+    @ElementCollection(fetch = FetchType.EAGER)
+    @Builder.Default
+    private List<String> roles = new ArrayList<>();
 
     public void update(MemberRequest memberRequest) {
 
         this.memberName = memberRequest.getMemberName();
         this.nickName = memberRequest.getNickName();
         this.password = memberRequest.getPassword();
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return this.roles.stream()
+                .map(SimpleGrantedAuthority::new)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public String getUsername() {
+        return null;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return false;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return false;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return false;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return false;
     }
 }

--- a/src/main/java/com/example/architecture/model/request/LoginRequest.java
+++ b/src/main/java/com/example/architecture/model/request/LoginRequest.java
@@ -1,0 +1,11 @@
+package com.example.architecture.model.request;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter @Setter
+public class LoginRequest {
+
+    private String nickName;
+    private String password;
+}

--- a/src/main/java/com/example/architecture/model/request/repository/MemberCondition.java
+++ b/src/main/java/com/example/architecture/model/request/repository/MemberCondition.java
@@ -1,0 +1,9 @@
+package com.example.architecture.model.request.repository;
+
+import com.example.architecture.model.request.baseRequest.BaseRequest;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter @Setter
+public class MemberCondition extends BaseRequest {
+}

--- a/src/main/java/com/example/architecture/repository/MemberRepository.java
+++ b/src/main/java/com/example/architecture/repository/MemberRepository.java
@@ -4,6 +4,9 @@ import com.example.architecture.model.entity.Member;
 import com.example.architecture.repository.generic.BaseRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface MemberRepository extends BaseRepository<Member> {
+    Optional<Member> findByNickName(String username);
 }

--- a/src/main/java/com/example/architecture/repository/MemberRepository.java
+++ b/src/main/java/com/example/architecture/repository/MemberRepository.java
@@ -1,12 +1,15 @@
 package com.example.architecture.repository;
 
 import com.example.architecture.model.entity.Member;
+import com.example.architecture.model.request.repository.MemberCondition;
+import com.example.architecture.model.response.MemberResponse;
 import com.example.architecture.repository.generic.BaseRepository;
+import com.example.architecture.repository.generic.CustomRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 
 @Repository
-public interface MemberRepository extends BaseRepository<Member> {
+public interface MemberRepository extends BaseRepository<Member>, CustomRepository<MemberCondition, MemberResponse> {
     Optional<Member> findByNickName(String username);
 }

--- a/src/main/java/com/example/architecture/repository/generic/CustomRepository.java
+++ b/src/main/java/com/example/architecture/repository/generic/CustomRepository.java
@@ -1,0 +1,7 @@
+package com.example.architecture.repository.generic;
+
+import java.util.List;
+
+public interface CustomRepository<Rq, Rs> {
+    List<Rs> findBy(Rq rq);
+}

--- a/src/main/java/com/example/architecture/repository/queryDsl/MemberRepositoryImpl.java
+++ b/src/main/java/com/example/architecture/repository/queryDsl/MemberRepositoryImpl.java
@@ -1,0 +1,20 @@
+package com.example.architecture.repository.queryDsl;
+
+import com.example.architecture.model.request.repository.MemberCondition;
+import com.example.architecture.model.response.MemberResponse;
+import com.example.architecture.repository.generic.CustomRepository;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+public class MemberRepositoryImpl implements CustomRepository<MemberCondition, MemberResponse> {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<MemberResponse> findBy(MemberCondition memberCondition) {
+        return null; // 관련 쿼리 작성 필요
+    }
+}

--- a/src/main/java/com/example/architecture/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/example/architecture/service/impl/MemberServiceImpl.java
@@ -1,14 +1,21 @@
 package com.example.architecture.service.impl;
 
+import com.example.architecture.jwt.JwtTokenProvider;
+import com.example.architecture.jwt.TokenInfo;
 import com.example.architecture.model.entity.Member;
 import com.example.architecture.model.request.MemberRequest;
 import com.example.architecture.model.response.MemberResponse;
 import com.example.architecture.repository.MemberRepository;
 import com.example.architecture.service.MemberService;
 import com.example.architecture.service.generic.impl.BaseServiceImpl;
+import org.apache.catalina.User;
 import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class MemberServiceImpl extends BaseServiceImpl<Member, MemberRequest, MemberResponse, MemberRepository> implements MemberService {
@@ -17,9 +24,13 @@ public class MemberServiceImpl extends BaseServiceImpl<Member, MemberRequest, Me
     MemberRepository memberRepository;
     @Autowired
     ModelMapper modelMapper;
+    private final AuthenticationManagerBuilder authenticationManagerBuilder;
+    private final JwtTokenProvider jwtTokenProvider;
 
-    public MemberServiceImpl(MemberRepository repository) {
+    public MemberServiceImpl(MemberRepository repository, AuthenticationManagerBuilder authenticationManagerBuilder, JwtTokenProvider jwtTokenProvider) {
         super(repository);
+        this.authenticationManagerBuilder = authenticationManagerBuilder;
+        this.jwtTokenProvider = jwtTokenProvider;
     }
 
     @Override
@@ -33,5 +44,21 @@ public class MemberServiceImpl extends BaseServiceImpl<Member, MemberRequest, Me
         } catch (Exception e) {
             throw  e;
         }
+    }
+
+    @Transactional
+    public TokenInfo login(String nickName, String password) {
+
+        // 1. Login ID/PW 를 기반으로 Authentication 객체 생성
+        // 이때 authentication 는 인증 여부를 확인하는 authenticated 값이 false
+        UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(nickName, password);
+
+        // 2. 실제 검증 (사용자 비밀번호 체크)가 이루어지는 부분
+        Authentication authentication = authenticationManagerBuilder.getObject().authenticate(authenticationToken);
+
+        // 3. 인증 정보를 기반으로 JWT 토큰 생성
+        TokenInfo tokenInfo = jwtTokenProvider.generateToken(authentication);
+
+        return tokenInfo;
     }
 }

--- a/src/main/java/com/example/architecture/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/example/architecture/service/impl/MemberServiceImpl.java
@@ -1,19 +1,17 @@
 package com.example.architecture.service.impl;
 
 import com.example.architecture.jwt.JwtTokenProvider;
-import com.example.architecture.jwt.TokenInfo;
 import com.example.architecture.model.entity.Member;
+import com.example.architecture.model.request.LoginRequest;
 import com.example.architecture.model.request.MemberRequest;
 import com.example.architecture.model.response.MemberResponse;
 import com.example.architecture.repository.MemberRepository;
 import com.example.architecture.service.MemberService;
 import com.example.architecture.service.generic.impl.BaseServiceImpl;
-import org.apache.catalina.User;
 import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
-import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,13 +22,28 @@ public class MemberServiceImpl extends BaseServiceImpl<Member, MemberRequest, Me
     MemberRepository memberRepository;
     @Autowired
     ModelMapper modelMapper;
-    private final AuthenticationManagerBuilder authenticationManagerBuilder;
+    @Autowired
+    BCryptPasswordEncoder passwordEncoder;
+
     private final JwtTokenProvider jwtTokenProvider;
 
-    public MemberServiceImpl(MemberRepository repository, AuthenticationManagerBuilder authenticationManagerBuilder, JwtTokenProvider jwtTokenProvider) {
+    public MemberServiceImpl(MemberRepository repository, JwtTokenProvider jwtTokenProvider) {
         super(repository);
-        this.authenticationManagerBuilder = authenticationManagerBuilder;
         this.jwtTokenProvider = jwtTokenProvider;
+    }
+
+    @Override
+    public MemberResponse save(MemberRequest request) throws Exception {
+        try {
+            String newPwd = passwordEncoder.encode(request.getPassword());
+            request.setPassword(newPwd);
+
+            Member entity = modelMapper.map(request, Member.class);
+            memberRepository.save(entity);
+            return modelMapper.map(entity, MemberResponse.class);
+        } catch (Exception e){
+            throw e;
+        }
     }
 
     @Override
@@ -47,18 +60,17 @@ public class MemberServiceImpl extends BaseServiceImpl<Member, MemberRequest, Me
     }
 
     @Transactional
-    public TokenInfo login(String nickName, String password) {
+    public String login(LoginRequest loginRequest) {
 
-        // 1. Login ID/PW 를 기반으로 Authentication 객체 생성
-        // 이때 authentication 는 인증 여부를 확인하는 authenticated 값이 false
-        UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(nickName, password);
+        Member findMember = memberRepository.findByNickName(loginRequest.getNickName())
+                .orElseThrow(() -> new UsernameNotFoundException("해당하는 유저를 찾을 수 없습니다."));
 
-        // 2. 실제 검증 (사용자 비밀번호 체크)가 이루어지는 부분
-        Authentication authentication = authenticationManagerBuilder.getObject().authenticate(authenticationToken);
+        if (!passwordEncoder.matches(loginRequest.getPassword(), findMember.getPassword())) {
 
-        // 3. 인증 정보를 기반으로 JWT 토큰 생성
-        TokenInfo tokenInfo = jwtTokenProvider.generateToken(authentication);
+            // Exception 추가 필요
+            return null;
+        }
 
-        return tokenInfo;
+        return jwtTokenProvider.createToken(findMember.getNickName(), findMember.getRoles());
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -8,3 +8,7 @@ spring:
   jpa:
     hibernate:
       ddl-auto: create
+
+jwt:
+  secret: MlwEyVEsYt9V7zq93TejMnVXyzblYcfPQye37f7MGVA9XkHaadb32dF
+  access-token-validity-in-seconds: 600 # 10min


### PR DESCRIPTION
## 변경 사항👀

### ✔️ 비밀번호 암호화
- spring security를 이용한 암호화 구현
- 가입시 암호화, 로그인 비밀번호 확인시 복호화

### ✔️ 로그인 기능
- access-token만을 이용한 로그인 구현
- 로그인 성공시 String으로 access-token 값 return

### ✔️ queryDSL 설정
- queryDSL 사용할 수 있도록 기본 설정 완료
- Q도메인 생성 확인

## 체크 사항 🔍

## 해야할 사항 📌

### 🙉 로그인 시, refresh token을 이용한 방법도 고민
- tokenInfo 객체를 이용하여 값을 전달할 수 있도록 구현
- 혹은 access-token 역시 tokenInfo 객체를 이용할 수 있도록 구현

### 🙉 DELETE 메소드 구현
- 구현되어 있는 delete는 DB에서 직접 삭제
    → 각 엔티티에 ENUM 혹은 boolean 컬럼을 추가해서 삭제 표시
    → GET 시에 가져오지 않도록 구현

### 🙉 queryDSL 구현
- post GET으로 가져올 때 원하는 필드만 가져올 수 있도록 구현
- 겹치는 필드는 최대한 CustomRequest로 뺄 수 있도록 구현